### PR TITLE
:bug: fix the wrong loop of the admin login block

### DIFF
--- a/Console-Based-Library-Management-System-main/code/library/LibraryManagementSystem.java
+++ b/Console-Based-Library-Management-System-main/code/library/LibraryManagementSystem.java
@@ -21,7 +21,7 @@ public class LibraryManagementSystem {
             System.out.println(boldTextStart +"======================================================================"+ boldTextEnd);
             System.out.println(boldTextStart + "**********Welcome to the Library Management System**********" + boldTextEnd);
             System.out.println(boldTextStart +"======================================================================"+ boldTextEnd);
-            System.out.println(boldTextStart +"1. Register"+ boldTextEnd);
+            System.out.println(boldTextStart +"1. Sign Up"+ boldTextEnd);
             System.out.println(boldTextStart +"2. Login"+ boldTextEnd);
             System.out.println(boldTextStart +"3. Administrator "+ boldTextEnd);
             System.out.println(boldTextStart +"4. Exit"+ boldTextEnd);

--- a/Console-Based-Library-Management-System-main/code/library/LibraryManagementSystem.java
+++ b/Console-Based-Library-Management-System-main/code/library/LibraryManagementSystem.java
@@ -132,7 +132,7 @@ public class LibraryManagementSystem {
                     if (admin.addBook(title, author, publicationDate, isbn, tags)) {
                         System.out.println(greenColorStart +"Book added successfully."+ resetGreenColor);
                     } else {
-                        System.out.println(redColorStart +"Failed to add book."+ resetColor);
+                        System.out.println(redColorStart +"Failed to add books."+ resetColor);
                     }
                     break;
                 case 3:


### PR DESCRIPTION
Before the modification, the administrator login screen will ask you to re-enter the wrong username and password, and you can't go back to the previous level to re-select the login. This time, if you enter the wrong username and password, you can choose to exit to the previous selection screen by typing "exit".